### PR TITLE
feat: allow skipping jinja parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ JSON object formatted as a string.
 schemachange will replace any variable placeholders before running your change script code and will throw an error if it
 finds any variable placeholders that haven't been replaced.
 
+If a script contains jinja-style syntax that should not be processed by schemachange, add the comment
+`-- schemachange-no-jinja` anywhere in the file. When this marker is present, schemachange will skip jinja rendering for
+that script and execute it as-is.
+
 #### Secrets filtering
 
 While many CI/CD tools already have the capability to filter secrets, it is best that any tool also does not output

--- a/schemachange/JinjaTemplateProcessor.py
+++ b/schemachange/JinjaTemplateProcessor.py
@@ -12,6 +12,8 @@ from schemachange.JinjaEnvVar import JinjaEnvVar
 
 logger = structlog.getLogger(__name__)
 
+_NO_JINJA_MARKER = "schemachange-no-jinja"
+
 
 class JinjaTemplateProcessor:
     _env_args = {
@@ -48,8 +50,14 @@ class JinjaTemplateProcessor:
             variables = {}
         # jinja needs posix path
         posix_path = Path(script).as_posix()
-        template = self.__environment.get_template(posix_path)
-        content = template.render(**variables).strip()
+        source, _, _ = self.__environment.loader.get_source(
+            self.__environment, posix_path
+        )
+        if _NO_JINJA_MARKER in source.lower():
+            content = source.strip()
+        else:
+            template = self.__environment.get_template(posix_path)
+            content = template.render(**variables).strip()
         content = content[:-1] if content.endswith(";") else content
         return content
 

--- a/tests/test_JinjaTemplateProcessor.py
+++ b/tests/test_JinjaTemplateProcessor.py
@@ -103,3 +103,15 @@ class TestJinjaTemplateProcessor:
         context = processor.render("test.sql", None)
 
         assert context == "some text myvar_default"
+
+    def test_render_ignores_jinja_when_marker_present(
+        self, processor: JinjaTemplateProcessor
+    ):
+        templates = {
+            "test.sql": "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"
+        }
+        processor.override_loader(DictLoader(templates))
+
+        context = processor.render("test.sql", {"should_ignore": "replacement"})
+
+        assert context == "-- schemachange-no-jinja\nselect '{{ should_ignore }}'"


### PR DESCRIPTION
## Summary
- add marker to bypass jinja rendering in scripts
- document marker usage
- test JinjaTemplateProcessor without rendering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fca7e33a48322b4801c1c25b3f9b1