### PR TITLE
Remove error logging to change history table

### DIFF
--- a/schemachange/session/SnowflakeSession.py
+++ b/schemachange/session/SnowflakeSession.py
@@ -168,7 +168,6 @@ class SnowflakeSession:
                 CHECKSUM VARCHAR,
                 EXECUTION_TIME NUMBER,
                 STATUS VARCHAR,
-                ERROR_MESSAGE VARCHAR,
                 INSTALLED_BY VARCHAR,
                 INSTALLED_ON TIMESTAMP_LTZ
             )
@@ -317,7 +316,6 @@ class SnowflakeSession:
         checksum = hashlib.sha224(script_content.encode("utf-8")).hexdigest()
         execution_time = 0
         status = "Success"
-        error_message = ""
         error: Exception | None = None
         start = time.time()
         if len(script_content) > 0:
@@ -328,58 +326,38 @@ class SnowflakeSession:
             except Exception as e:
                 status = "Failed"
                 error = e
-                error_message = str(e).replace("'", "''")
             finally:
                 self.reset_query_tag(logger=logger)
                 self.reset_session(logger=logger)
                 end = time.time()
                 execution_time = round(end - start)
 
-        # Compose and execute the insert statement to the log file
-        script_version = getattr(script, "version", "")
-        query = f"""\
-            INSERT INTO {self.change_history_table.fully_qualified} (
-                VERSION,
-                DESCRIPTION,
-                SCRIPT,
-                SCRIPT_TYPE,
-                CHECKSUM,
-                EXECUTION_TIME,
-                STATUS,
-                ERROR_MESSAGE,
-                INSTALLED_BY,
-                INSTALLED_ON
-            ) VALUES (
-                '{script_version}',
-                '{script.description}',
-                '{script.name}',
-                '{script.type}',
-                '{checksum}',
-                {execution_time},
-                '{status}',
-                '{error_message}',
-                '{self.user}',
-                CURRENT_TIMESTAMP
-            );
-        """
-        dedent_query = dedent(query)
-        try:
-            self.execute_snowflake_query(dedent_query, logger=logger)
-        except snowflake.connector.errors.ProgrammingError as e:
-            if "ERROR_MESSAGE" in str(e):
-                logger.warning(
-                    "Change history table missing ERROR_MESSAGE column, adding column",
-                    error=str(e),
-                )
-                alter_query = (
-                    f"ALTER TABLE {self.change_history_table.fully_qualified} "
-                    "ADD COLUMN IF NOT EXISTS ERROR_MESSAGE VARCHAR"
-                )
-                self.execute_snowflake_query(alter_query, logger=logger)
-                self.execute_snowflake_query(dedent_query, logger=logger)
-            else:
-                raise
-        if status != "Success":
-            raise Exception(
-                f"Failed to execute {script.name}: {error_message}"
-            ) from error
+        if status == "Success":
+            # Compose and execute the insert statement to the log file
+            script_version = getattr(script, "version", "")
+            query = f"""\
+                INSERT INTO {self.change_history_table.fully_qualified} (
+                    VERSION,
+                    DESCRIPTION,
+                    SCRIPT,
+                    SCRIPT_TYPE,
+                    CHECKSUM,
+                    EXECUTION_TIME,
+                    STATUS,
+                    INSTALLED_BY,
+                    INSTALLED_ON
+                ) VALUES (
+                    '{script_version}',
+                    '{script.description}',
+                    '{script.name}',
+                    '{script.type}',
+                    '{checksum}',
+                    {execution_time},
+                    '{status}',
+                    '{self.user}',
+                    CURRENT_TIMESTAMP
+                );
+            """
+            self.execute_snowflake_query(dedent(query), logger=logger)
+        else:
+            raise Exception(f"Failed to execute {script.name}: {error}") from error

--- a/tests/session/test_SnowflakeSession.py
+++ b/tests/session/test_SnowflakeSession.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 import structlog
-from snowflake.connector.errors import ProgrammingError
 
 from schemachange.config.ChangeHistoryTable import ChangeHistoryTable
 from schemachange.session.SnowflakeSession import SnowflakeSession
@@ -51,49 +50,16 @@ class TestSnowflakeSession:
         assert session.con.execute_string.call_count == 1
         assert session.logger.calls[1][1][0] == "Executing query"
 
-    def test_apply_change_script_failure_records_history(
+    def test_apply_change_script_failure_does_not_record_history(
         self, session: SnowflakeSession
     ):
         script = VersionedScript.from_path(Path("V1__test.sql"))
-        session.execute_snowflake_query = mock.Mock(
-            side_effect=[Exception("boom"), None]
-        )
+        session.execute_snowflake_query = mock.Mock(side_effect=[Exception("boom")])
         with (
             mock.patch.object(session, "reset_session"),
             mock.patch.object(session, "reset_query_tag"),
             pytest.raises(Exception),
         ):
             session.apply_change_script(script, "select 1", False, session.logger)
-        assert session.execute_snowflake_query.call_count == 2
-        insert_query = session.execute_snowflake_query.call_args_list[1].args[0]
-        assert "Failed" in insert_query
-        assert "ERROR_MESSAGE" in insert_query
-        assert "boom" in insert_query
-
-    def test_apply_change_script_missing_error_message_column(
-        self, session: SnowflakeSession
-    ):
-        script = VersionedScript.from_path(Path("V1__test.sql"))
-        session.execute_snowflake_query = mock.Mock(
-            side_effect=[
-                Exception("boom"),
-                ProgrammingError("invalid identifier 'ERROR_MESSAGE'", 0, 0),
-                None,
-                None,
-            ]
-        )
-        with (
-            mock.patch.object(session, "reset_session"),
-            mock.patch.object(session, "reset_query_tag"),
-            pytest.raises(Exception),
-        ):
-            session.apply_change_script(script, "select 1", False, session.logger)
-        assert session.execute_snowflake_query.call_count == 4
-        first_insert = session.execute_snowflake_query.call_args_list[1].args[0]
-        alter_stmt = session.execute_snowflake_query.call_args_list[2].args[0]
-        retry_insert = session.execute_snowflake_query.call_args_list[3].args[0]
-        assert "ERROR_MESSAGE" in first_insert
-        assert "ALTER TABLE" in alter_stmt
-        assert "ADD COLUMN" in alter_stmt
-        assert "ERROR_MESSAGE" in alter_stmt
-        assert "ERROR_MESSAGE" in retry_insert
+        # Only the script execution should be attempted
+        assert session.execute_snowflake_query.call_count == 1


### PR DESCRIPTION
## Summary
- skip logging failed scripts to change history table
- drop ERROR_MESSAGE column from change history table
- adjust tests for new behavior

## Testing
- `pytest tests/session/test_SnowflakeSession.py`

